### PR TITLE
Allow passing objects in API

### DIFF
--- a/src/pantry/common.nim
+++ b/src/pantry/common.nim
@@ -38,6 +38,12 @@ type
   TooManyPantryRequests* = object of PantryError
     ## Raised when you are calling pantry too many times (limit is 2 times per second)
 
+  BasketDoesntExist* = object of PantryError
+    ## Raised if you make a request to a basket that doesn't exist
+
+  InvalidPantryID* = object of PantryError
+    ## Raised if you make a request use a pantry ID that is invalid
+
   RetryStrategy* = enum
     ## Strategy to imploy when pantry gives a `too many requests` error
     ## * **Exception**: Throws an exception (default)

--- a/src/pantry/common.nim
+++ b/src/pantry/common.nim
@@ -1,6 +1,5 @@
 import std/httpclient
 import std/tables
-import std/times
 
 
 

--- a/tests/testFull.nim
+++ b/tests/testFull.nim
@@ -39,4 +39,19 @@ suite "Basket":
   test "Delete":
     pc.delete("demo")
     check not pc.getDetails().baskets.hasKey("demo")
-  
+
+type 
+  Item = object
+    name: string
+    price: float
+    
+  Order = object
+    time: int
+    items: seq[Item]
+
+test "Objects":
+  var order = Order(time: 123456789, items: @[
+    Item(name: "Soap", price:  0.49),
+    Item(name: "Crisps", price: 0.70)
+  ])
+  pc.create("order", order)


### PR DESCRIPTION
Enables using objects instead of `JsonNode`
Example:
```nim
type
  Person = object
    age: int
    name: string

pc.create("manager", Person(age: 25, name: "John"))
```
Also enables using `Option[T]` to avoid having to handle exceptions
```nim
import std/options
# Manager doesn't exist anymore
pc.delete("manager")

# This will throw exception
let manager = pc.get("manager", Person) 

# This will just return none
let someManager = pc.get("manager", Option[Person])
assert someManager.isNone
```
