### PR TITLE
Automatically define SSL so the user doesn't need to

### DIFF
--- a/src/pantry.nim
+++ b/src/pantry.nim
@@ -246,7 +246,6 @@ proc request(pc: PantryClient | AsyncPantryClient, path: string,
       "Content-Type": "application/json"
     }
   )
-  echo resp.headers
   let msg = await resp.body
   case resp.code.int
   of 200..299:

--- a/src/pantry.nim
+++ b/src/pantry.nim
@@ -1,3 +1,5 @@
+{.define: ssl.}
+
 import std/[
   httpclient,
   asyncdispatch,

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,2 +1,1 @@
 switch("path", "$projectDir/../src")
-switch("d", "ssl")


### PR DESCRIPTION
Defines `ssl` so that the users don't need to define it when importing pantry